### PR TITLE
Primeira loot_table feita

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,6 @@
+{
+    "values":
+    [
+        "ordem_paranormal:madeira_ensanguentada"
+    ]
+}

--- a/src/main/resources/data/ordem_paranormal/loot_tables/blocks/madeira_ensanguentada.json
+++ b/src/main/resources/data/ordem_paranormal/loot_tables/blocks/madeira_ensanguentada.json
@@ -1,0 +1,22 @@
+{
+    "type": "minecraft:block",
+    "pools":
+    [
+        {
+            "bonus_rolls":  0.0,
+            "conditions": 
+            [
+                {"condition": "minecraft:survives_explosion"}
+            ],
+            "entries":
+            [
+                {
+                    "type": "minecraft:item",
+                    "name": "ordem_paranormal:madeira_ensanguentada"
+                }
+            ],
+            "rolls": 1.0
+        }
+    ],
+    "random_sequence": "ordem_paranormal:blocks/madeira_ensanguentada"
+}


### PR DESCRIPTION
Loot_tabl da madeira ensanguentada, agora quando minerada dropa o própio item, além de ser quebrada mais rápido se utilizando um machado (tal qual madeira de carvalho)